### PR TITLE
Report Overall Code Coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ test_artifacts:
           assertSuccess(results);
     BLOCK
     matlab -batch runAllTests
-artifacts:
+  artifacts:
     reports:
       junit: "./artifacts/results.xml"
       coverage_report:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ test_artifacts:
           runner.addPlugin(CodeCoveragePlugin.forFolder(pwd,'IncludingSubfolders',true, ...
           'Producing',CoberturaFormat('artifacts/cobertura.xml')))
           results = runner.run(suite)
+          ftext = string(fileread('artifacts/cobertura.xml'));
+          linerate = regexp(ftext,'line-rate=\"(\d+.\d+)\"','tokens','once');
+          fprintf('\nCode Coverage %i%%\n',round(str2double(linerate)*100));
           assertSuccess(results);
     BLOCK
     matlab -batch runAllTests
@@ -83,6 +86,7 @@ test_artifacts:
         path: "./artifacts/cobertura.xml"
     paths:
       - "./artifacts"
+  coverage: '/Code Coverage.*\s+(\d+%)$/'
 ```
 
 ### Run MATLAB Build


### PR DESCRIPTION
Extract the overall code coverage from the Cobertura report and report it using the [code coverage reporting keyword](https://docs.gitlab.com/ci/testing/code_coverage/#configure-coverage-reporting) (note: this is different than the [Coverage Visualization report](https://docs.gitlab.com/ci/testing/code_coverage/#coverage-visualization)). This will ensure that both the project badges reporting code coverage and the report coverage changes on the Merge request widget work.

Drive-by: Fix indentation of `artifacts` underneath the test job.